### PR TITLE
xilinx_axienet: Enable 1000BaseX Phys with axi driver

### DIFF
--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
@@ -941,7 +941,8 @@ static int axienet_open(struct net_device *ndev)
 		return ret;
 
 	if (lp->phy_node) {
-		if (lp->phy_type == XAE_PHY_TYPE_GMII) {
+		if (lp->phy_type == XAE_PHY_TYPE_GMII ||
+		    lp->phy_type == XAE_PHY_TYPE_1000BASE_X) {
 			lp->phy_dev = of_phy_connect(lp->ndev, lp->phy_node,
 					     axienet_adjust_link, 0,
 					     PHY_INTERFACE_MODE_GMII);


### PR DESCRIPTION
1000BaseX Phys also communicate with GMII. Enable this when setting up the driver.
