### PR TITLE
rpmsg_proto: Remove inclusion of rwmutex.h

### DIFF
--- a/net/rpmsg/rpmsg_proto.c
+++ b/net/rpmsg/rpmsg_proto.c
@@ -24,7 +24,6 @@
 #include <linux/list.h>
 #include <linux/errno.h>
 #include <linux/skbuff.h>
-#include <linux/rwlock.h>
 #include <linux/err.h>
 #include <linux/mutex.h>
 #include <linux/rpmsg.h>


### PR DESCRIPTION
This causes redefinition of rwlock functionality that conflicts on
PREEMPT_RT builds. Besides, as the headers themselves say, don't
include the file directly.

Signed-off-by: Brad Mouring brad.mouring@ni.com
