### PR TITLE
axidma: xilinx: Fix constant compilation error

### DIFF
--- a/include/linux/amba/xilinx_dma.h
+++ b/include/linux/amba/xilinx_dma.h
@@ -18,6 +18,7 @@
 /* DMA IP masks */
 #define XILINX_DMA_IP_DMA	0x00100000	/* A DMA IP */
 #define XILINX_DMA_IP_CDMA	0x00200000	/* A Central DMA IP */
+#define XILINX_DMA_IP_VDMA	0x00400000	/* A Video DMA IP */
 
 /* Device Id in the private structure */
 #define XILINX_DMA_DEVICE_ID_SHIFT	28


### PR DESCRIPTION
Add XILINX_DMA_IP_VDMA to avoid compilation error in axidma

Signed-off-by: Javier Gonzalez jgon@itu.dk
