### PR TITLE
dma: last actions in xilinx_dma_chan_remove put under check for irq > 0

### DIFF
--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -996,12 +996,13 @@ static void xilinx_dma_chan_remove(struct xilinx_dma_chan *chan)
 	chan->ctrl_reg &= ~XILINX_DMA_XR_IRQ_ALL_MASK;
 	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 
-	if (chan->irq > 0)
+	if (chan->irq > 0) {
 		free_irq(chan->irq, chan);
 
-	tasklet_kill(&chan->tasklet);
+		tasklet_kill(&chan->tasklet);
 
-	list_del(&chan->common.device_node);
+		list_del(&chan->common.device_node);
+	}
 }
 
 /**


### PR DESCRIPTION
I am new to driver or kernel editing, so please forgive me if I made any mistakes here.  

I had noticed prior to this change that if I left the "interrupt-parent" parameter out of my device tree that the system would fail to boot.  No errors would even be produced to my serial console.  Since it seems that the tasklet, etc. should not be created in such cases that the last commands should not be run in xilinx_dma_chan_remove unless chan->irq was greater than 0.  

It would not surprise me if there are additional changes that ought to be made (or a different form of change) to solve this problem.  
