### PR TITLE
fix:Null pointer errors with RBG24 format

### DIFF
--- a/drivers/media/platform/xilinx/xilinx-vip.c
+++ b/drivers/media/platform/xilinx/xilinx-vip.c
@@ -32,7 +32,7 @@ static const struct xvip_video_format xvip_video_formats[] = {
 	{ XVIP_VF_YUV_444, 8, NULL, MEDIA_BUS_FMT_VUY8_1X24,
 	  3, V4L2_PIX_FMT_YUV444, "4:4:4, packed, YUYV" },
 	{ XVIP_VF_RBG, 8, NULL, MEDIA_BUS_FMT_RBG888_1X24,
-	  3, 0, NULL },
+	  3, 0, "RGB24(LE)" },
 	{ XVIP_VF_MONO_SENSOR, 8, "mono", MEDIA_BUS_FMT_Y8_1X8,
 	  1, V4L2_PIX_FMT_GREY, "Greyscale 8-bit" },
 	{ XVIP_VF_MONO_SENSOR, 8, "rggb", MEDIA_BUS_FMT_SRGGB8_1X8,


### PR DESCRIPTION
when the video to be processed is RBG24 format, the value of xvip_video_format.description would be NULL, therefore this line of code "strlcpy(f->description, dma->fmtinfo->description, sizeof(f->description)); "(drivers/media/platform/xilinx/xilinx-dma.c:554) will be processing NULL pointer.
