### PR TITLE
Fix CAN0 off chip transceiver enable issue for ZC702 board.

### DIFF
--- a/Documentation/devicetree/bindings/net/can/xilinx_can.txt
+++ b/Documentation/devicetree/bindings/net/can/xilinx_can.txt
@@ -17,6 +17,9 @@ Required properties:
 - tx-fifo-depth		: Can Tx fifo depth.
 - rx-fifo-depth		: Can Rx fifo depth.
 
+Optional properties:
+- transceiver-enable    : Provide the GPIO pin that controls the CAN transceiver.
+			  Flags can be 0 [Active High] or 1 [Active Low].
 
 Example:
 
@@ -41,4 +44,16 @@ For Axi CAN Dts file:
 			interrupts = <0 59 1>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
+		};
+For ZC702 CAN Dts file:
+	can_0: can@e0008000 {
+			clocks = <&clkc 19>, <&clkc 36>;
+			clock-names = "can_clk", "pclk";
+			compatible = "xlnx,zynq-can-1.0";
+			interrupt-parent = <&ps7_scugic_0>;
+			interrupts = <0 28 4>;
+			reg = <0xe0008000 0x1000>;
+			tx-fifo-depth = <0x40>;
+			rx-fifo-depth = <0x40>;
+			transceiver-enable = <&gpio0 9 1>;
 		};

--- a/arch/arm/boot/dts/zynq-zc702.dts
+++ b/arch/arm/boot/dts/zynq-zc702.dts
@@ -115,6 +115,7 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_can0_default>;
+	transceiver-enable = <&gpio0 9 1>;
 };
 
 &clkc {


### PR DESCRIPTION
1. Add support in xilinx_can driver to drive the transceiver enable pin if defined in device tree.
2. Add the transceiver enable pin entry for can0 node in the DTS of zc702 board.

---
Signed-off-by: Adeel Arshad <adeel_arshad@mentor.com>