### PR TITLE
Fix video format cannot be set in VDMA engine(xilinx-v2014.4)

### DIFF
--- a/drivers/dma/xilinx/xilinx_vdma.c
+++ b/drivers/dma/xilinx/xilinx_vdma.c
@@ -1087,12 +1087,22 @@ static int xilinx_vdma_device_control(struct dma_chan *dchan,
 				      enum dma_ctrl_cmd cmd, unsigned long arg)
 {
 	struct xilinx_vdma_chan *chan = to_xilinx_chan(dchan);
-
-	if (cmd != DMA_TERMINATE_ALL)
+	
+	if (!dchan)
+		return -EINVAL;
+		
+	switch(cmd){
+	case DMA_TERMINATE_ALL:
+		xilinx_vdma_terminate_all(chan);
+		break;
+	case DMA_SLAVE_CONFIG:
+		struct xilinx_vdma_config *cfg = (struct xilinx_vdma_config *)arg;
+		xilinx_vdma_channel_set_config(dchan, cfg);
+		break;
+	default:
 		return -ENXIO;
-
-	xilinx_vdma_terminate_all(chan);
-
+	}
+	
 	return 0;
 }
 


### PR DESCRIPTION
VDMA engine need DMA_SLAVE_CONFIG method when V4L2 driver set video format(ps:xilinx-v2014.4/drivers/media/platform/xilinx/xilinx-dma.c:654). 