### PR TITLE
Fix video format cannot be set in VDMA engine(xilinx-v2014.4)

### DIFF
--- a/arch/arm/boot/dts/zynq-zc702.dts
+++ b/arch/arm/boot/dts/zynq-zc702.dts
@@ -92,10 +92,6 @@
 	status = "okay";
 };
 
-&can0 {
-	status = "okay";
-};
-
 &gem0 {
 	status = "okay";
 	phy-mode = "rgmii-id";


### PR DESCRIPTION
VDMA engine need DMA_SLAVE_CONFIG method when V4L2 driver set video format(ps:xilinx-v2014.4/drivers/media/platform/xilinx/xilinx-dma.c:654).
