### PR TITLE
AXI DMA Driver bugfixes/improvements

### DIFF
--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -85,7 +85,7 @@
 #define XILINX_DMA_NUM_APP_WORDS	5
 
 #define xilinx_dma_poll_timeout(chan, reg, val, cond, delay_us, timeout_us) \
-	readl_poll_timeout(chan->xdev->regs + chan->ctrl_offset + reg, val, \
+	readl_poll_timeout_atomic(chan->xdev->regs + chan->ctrl_offset + reg, val, \
 			   cond, delay_us, timeout_us)
 
 /**

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -751,6 +751,7 @@ static int xilinx_dma_chan_reset(struct xilinx_dma_chan *chan)
 	}
 
 	chan->err = false;
+	chan->idle = true;
 
 	return err;
 }
@@ -1102,6 +1103,9 @@ static int xilinx_dma_terminate_all(struct dma_chan *dchan)
 
 	/* Halt the DMA engine */
 	xilinx_dma_halt(chan);
+
+	if (chan->err)
+		xilinx_dma_chan_reset(chan);
 
 	/* Remove and free all of the descriptors in the lists */
 	xilinx_dma_free_descriptors(chan);

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -30,6 +30,7 @@
 #include <linux/of_irq.h>
 #include <linux/of_platform.h>
 #include <linux/slab.h>
+#include <linux/dmapool.h>
 
 #include "../dmaengine.h"
 
@@ -80,8 +81,6 @@
 /* Delay loop counter to prevent hardware failure */
 #define XILINX_DMA_LOOP_COUNT		1000000
 
-/* Maximum number of Descriptors */
-#define XILINX_DMA_NUM_DESCS		255
 #define XILINX_DMA_NUM_APP_WORDS	5
 
 #define xilinx_dma_poll_timeout(chan, reg, val, cond, delay_us, timeout_us) \
@@ -148,7 +147,6 @@ struct xilinx_dma_tx_descriptor {
  * @pending_list: Descriptors waiting
  * @active_list: Descriptors ready to submit
  * @done_list: Complete descriptors
- * @free_seg_list: Free descriptors
  * @common: DMA common channel
  * @seg_v: Statically allocated segments base
  * @seg_p: Physical allocated segments base
@@ -160,6 +158,8 @@ struct xilinx_dma_tx_descriptor {
  * @err: Channel has errors
  * @tasklet: Cleanup work after irq
  * @residue: Residue
+ * @seg_pool: DMA Segment (Buffer Descriptor) Pool
+ * @seg_reserve: Extra allocated segment.
  */
 struct xilinx_dma_chan {
 	struct xilinx_dma_device *xdev;
@@ -169,7 +169,6 @@ struct xilinx_dma_chan {
 	struct list_head pending_list;
 	struct list_head done_list;
 	struct list_head active_list;
-	struct list_head free_seg_list;
 	struct dma_chan common;
 	struct xilinx_dma_tx_segment *seg_v;
 	dma_addr_t seg_p;
@@ -182,6 +181,14 @@ struct xilinx_dma_chan {
 	bool idle;
 	struct tasklet_struct tasklet;
 	u32 residue;
+	struct dma_pool *seg_pool;
+
+	/* seg_reserve: For non-cyclic mode, after submitting a pending_list, keep
+	 * an extra segment allocated so that the "next descriptor" pointer on the
+	 * tail descriptor always points to a valid descriptor, even when paused
+	 * after reaching taildesc.  This way, it is possible to issue additional
+	 * transfers without halting and restarting the channel. */
+	struct xilinx_dma_tx_segment *seg_reserve;
 };
 
 /**
@@ -257,33 +264,19 @@ static struct xilinx_dma_tx_segment *
 xilinx_dma_alloc_tx_segment(struct xilinx_dma_chan *chan)
 {
 	struct xilinx_dma_tx_segment *segment = NULL;
-	unsigned long flags;
+	dma_addr_t pdesc;
 
-	spin_lock_irqsave(&chan->lock, flags);
-	if (!list_empty(&chan->free_seg_list)) {
-		segment = list_first_entry(&chan->free_seg_list,
-					   struct xilinx_dma_tx_segment,
-					   node);
-		list_del(&segment->node);
-	}
-	spin_unlock_irqrestore(&chan->lock, flags);
+	gfp_t gfp_flags = GFP_ATOMIC;
+
+	segment = dma_pool_alloc(chan->seg_pool, gfp_flags, &pdesc);
+	if (!segment)
+		return NULL;
+
+	memset(segment, 0, sizeof(*segment));
+	INIT_LIST_HEAD(&segment->node);
+	segment->phys = pdesc;
 
 	return segment;
-}
-
-/**
- * xilinx_dma_clean_hw_desc - Clean hardware descriptor
- * @hw: HW descriptor to clean
- */
-static void xilinx_dma_clean_hw_desc(struct xilinx_dma_desc_hw *hw)
-{
-	u32 next_desc = hw->next_desc;
-	u32 next_desc_msb = hw->next_desc_msb;
-
-	memset(hw, 0, sizeof(struct xilinx_dma_desc_hw));
-
-	hw->next_desc = next_desc;
-	hw->next_desc_msb = next_desc_msb;
 }
 
 /**
@@ -294,9 +287,7 @@ static void xilinx_dma_clean_hw_desc(struct xilinx_dma_desc_hw *hw)
 static void xilinx_dma_free_tx_segment(struct xilinx_dma_chan *chan,
 				       struct xilinx_dma_tx_segment *segment)
 {
-	xilinx_dma_clean_hw_desc(&segment->hw);
-
-	list_add_tail(&segment->node, &chan->free_seg_list);
+	dma_pool_free(chan->seg_pool, segment, segment->phys);
 }
 
 /**
@@ -326,7 +317,7 @@ xilinx_dma_alloc_tx_descriptor(struct xilinx_dma_chan *chan)
  */
 static void
 xilinx_dma_free_tx_descriptor(struct xilinx_dma_chan *chan,
-			      struct xilinx_dma_tx_descriptor *desc)
+	struct xilinx_dma_tx_descriptor *desc)
 {
 	struct xilinx_dma_tx_segment *segment, *next;
 
@@ -350,36 +341,29 @@ xilinx_dma_free_tx_descriptor(struct xilinx_dma_chan *chan,
 static int xilinx_dma_alloc_chan_resources(struct dma_chan *dchan)
 {
 	struct xilinx_dma_chan *chan = to_xilinx_chan(dchan);
-	int i;
 
-	/* Allocate the buffer descriptors. */
-	chan->seg_v = dma_zalloc_coherent(chan->dev,
-					  sizeof(*chan->seg_v) *
-					  XILINX_DMA_NUM_DESCS,
-					  &chan->seg_p, GFP_KERNEL);
-	if (!chan->seg_v) {
+	chan->seg_pool =
+		dma_pool_create("xilinx_dma_seg_pool", chan->dev,
+				sizeof(struct xilinx_dma_tx_segment),
+				__alignof__(struct xilinx_dma_tx_segment), 0);
+
+	if (!chan->seg_pool) {
 		dev_err(chan->dev,
-			"unable to allocate channel %d descriptors\n",
+			"unable to allocate channel %d descriptor pool\n",
 			chan->id);
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < XILINX_DMA_NUM_DESCS; i++) {
-#ifdef CONFIG_PHYS_ADDR_T_64BIT
-		chan->seg_v[i].hw.next_desc =
-		lower_32_bits(chan->seg_p + sizeof(*chan->seg_v) *
-			((i + 1) % XILINX_DMA_NUM_DESCS));
-		chan->seg_v[i].hw.next_desc_msb =
-		upper_32_bits(chan->seg_p + sizeof(*chan->seg_v) *
-			((i + 1) % XILINX_DMA_NUM_DESCS));
-#else
-		chan->seg_v[i].hw.next_desc =
-			chan->seg_p + sizeof(*chan->seg_v) *
-			((i + 1) % XILINX_DMA_NUM_DESCS);
-#endif
-
-		chan->seg_v[i].phys = chan->seg_p + sizeof(*chan->seg_v) * i;
-		list_add_tail(&chan->seg_v[i].node, &chan->free_seg_list);
+	BUG_ON( chan->seg_reserve );
+	chan->seg_reserve = xilinx_dma_alloc_tx_segment(chan);
+	
+	if ( !chan->seg_reserve )
+	{
+		dev_err(chan->dev,
+	        "unable to allocate segment from new descriptor pool\n");
+	    dma_pool_destroy( chan->seg_pool );
+	    chan->seg_pool = NULL;
+		return -ENOMEM;
 	}
 
 	dma_cookie_init(dchan);
@@ -433,17 +417,29 @@ static void xilinx_dma_free_chan_resources(struct dma_chan *dchan)
 	struct xilinx_dma_chan *chan = to_xilinx_chan(dchan);
 	unsigned long flags;
 
+	struct dma_pool *pool_to_free = NULL;
+	struct xilinx_dma_tx_segment *seg_to_free = NULL;
+
 	xilinx_dma_free_descriptors(chan);
 
-	/* Remove all segments from free segment list */
+	/* Free memory that was allocated for the segments (from non-atomic context) */
 	spin_lock_irqsave(&chan->lock, flags);
-	INIT_LIST_HEAD(&chan->free_seg_list);
+
+	seg_to_free = chan->seg_reserve;
+	chan->seg_reserve = NULL;
+
+	pool_to_free = chan->seg_pool;
+	chan->seg_pool = NULL;
+
 	spin_unlock_irqrestore(&chan->lock, flags);
 
-	/* Free memory that was allocated for the segments */
-	dma_free_coherent(chan->dev,
-			  sizeof(*chan->seg_v) * XILINX_DMA_NUM_DESCS,
-			  chan->seg_v, chan->seg_p);
+	if (pool_to_free) {
+		if (seg_to_free) {
+			/* no longer safe to call xilinx_dma_free_tx_segment() here */
+			dma_pool_free(pool_to_free, seg_to_free, seg_to_free->phys);
+		}
+		dma_pool_destroy( pool_to_free );
+	}
 }
 
 /**
@@ -611,6 +607,7 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 {
 	struct xilinx_dma_tx_descriptor *head_desc, *tail_desc;
 	struct xilinx_dma_tx_segment *tail_segment;
+	dma_addr_t head_seg_phys;
 
 	if (chan->err)
 		return;
@@ -628,18 +625,48 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 	tail_segment = list_last_entry(&tail_desc->segments,
 				       struct xilinx_dma_tx_segment, node);
 
+	/* If channel is not halted, the tail descriptor's next_desc points to
+	 * chan->seg_reserve.  Swap head_segment and chan->seg_reserve, keeping
+	 * Buffer Descriptor contents from head_segment. */
+	{
+	    struct xilinx_dma_tx_segment *old_head, *new_head;
+
+		old_head = list_first_entry(&head_desc->segments,
+					struct xilinx_dma_tx_segment, node);
+		new_head = chan->seg_reserve;
+
+		/* Copy Buffer Descriptor fields. */
+		new_head->hw = old_head->hw;
+
+		/* Swap and save new reserve */
+		list_replace_init( &old_head->node, &new_head->node );
+		chan->seg_reserve = old_head;
+
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+		tail_segment->hw.next_desc     = lower_32_bits(chan->seg_reserve->phys);
+		tail_segment->hw.next_desc_msb = upper_32_bits(chan->seg_reserve->phys);
+#else
+		tail_segment->hw.next_desc = chan->seg_reserve->phys;
+#endif
+
+		head_seg_phys = new_head->phys;
+	}
+
 	chan->ctrl_reg &= ~XILINX_DMA_CR_COALESCE_MAX;
 	chan->ctrl_reg |= 1 << XILINX_DMA_CR_COALESCE_SHIFT;    // setting IrqThreshold != 1 is unreliable
 	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 
 	if (chan->has_sg)
+	{
+		BUG_ON( head_seg_phys & 0x3F );
 #ifdef CONFIG_PHYS_ADDR_T_64BIT
 		dma_ctrl_writeq(chan, XILINX_DMA_REG_CURDESC,
-			       head_desc->async_tx.phys);
+			       head_seg_phys );
 #else
 		dma_ctrl_write(chan, XILINX_DMA_REG_CURDESC,
-			       head_desc->async_tx.phys);
+			       head_seg_phys);
 #endif
+	}
 
 	xilinx_dma_start(chan);
 
@@ -648,6 +675,9 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 
 	/* Start the transfer */
 	if (chan->has_sg) {
+
+		BUG_ON( !tail_segment->phys || tail_segment->phys & 0x3F );
+
 #ifdef CONFIG_PHYS_ADDR_T_64BIT
 		dma_ctrl_writeq(chan, XILINX_DMA_REG_TAILDESC,
 			       tail_segment->phys);
@@ -823,7 +853,7 @@ static void xilinx_dma_do_tasklet(unsigned long data)
 static void append_desc_queue(struct xilinx_dma_chan *chan,
 			      struct xilinx_dma_tx_descriptor *desc)
 {
-	struct xilinx_dma_tx_segment *tail_segment;
+	struct xilinx_dma_tx_segment *tail_segment, *new_head_segment;
 	struct xilinx_dma_tx_descriptor *tail_desc;
 
 	if (list_empty(&chan->pending_list))
@@ -837,7 +867,16 @@ static void append_desc_queue(struct xilinx_dma_chan *chan,
 				    struct xilinx_dma_tx_descriptor, node);
 	tail_segment = list_last_entry(&tail_desc->segments,
 				       struct xilinx_dma_tx_segment, node);
-	tail_segment->hw.next_desc = (u32)desc->async_tx.phys;
+
+	new_head_segment = list_first_entry(&desc->segments,
+				       struct xilinx_dma_tx_segment, node);
+
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+	tail_segment->hw.next_desc     = lower_32_bits(new_head_segment->phys);
+	tail_segment->hw.next_desc_msb = upper_32_bits(new_head_segment->phys);
+#else
+	tail_segment->hw.next_desc = new_head_segment->phys;
+#endif
 
 	/*
 	 * Add the software descriptor and all children to the list
@@ -909,7 +948,7 @@ static struct dma_async_tx_descriptor *xilinx_dma_prep_slave_sg(
 {
 	struct xilinx_dma_chan *chan = to_xilinx_chan(dchan);
 	struct xilinx_dma_tx_descriptor *desc;
-	struct xilinx_dma_tx_segment *segment;
+	struct xilinx_dma_tx_segment *segment = NULL;
 	u32 *app_w = (u32 *)context;
 	struct scatterlist *sg;
 	size_t copy, sg_used;
@@ -936,9 +975,22 @@ static struct dma_async_tx_descriptor *xilinx_dma_prep_slave_sg(
 			struct xilinx_dma_desc_hw *hw;
 
 			/* Get a free segment */
-			segment = xilinx_dma_alloc_tx_segment(chan);
-			if (!segment)
-				goto error;
+			{
+				struct xilinx_dma_tx_segment *prev_segment = segment;
+
+				segment = xilinx_dma_alloc_tx_segment(chan);
+				if (!segment)
+					goto error;
+
+				if ( prev_segment ) {   // link prev -> current
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+					prev_segment->hw.next_desc_msb = upper_32_bits(segment->phys);
+					prev_segment->hw.next_desc     = lower_32_bits(segment->phys);
+#else
+					prev_segment->hw.next_desc = segment->phys;
+#endif
+				}
+			}
 
 			/*
 			 * Calculate the maximum number of bytes to transfer,
@@ -976,9 +1028,22 @@ static struct dma_async_tx_descriptor *xilinx_dma_prep_slave_sg(
 		}
 	}
 
-	segment = list_first_entry(&desc->segments,
-				   struct xilinx_dma_tx_segment, node);
-	desc->async_tx.phys = segment->phys;
+	{
+		struct xilinx_dma_tx_segment *last_segment = segment;
+
+		segment = list_first_entry(&desc->segments,
+					   struct xilinx_dma_tx_segment, node);
+
+		/* Link last segment to first */
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+		last_segment->hw.next_desc     = lower_32_bits(segment->phys);
+		last_segment->hw.next_desc_msb = upper_32_bits(segment->phys);
+#else
+		last_segment->hw.next_desc = segment->phys;
+#endif
+	}
+
+	desc->async_tx.phys = segment->phys;    // first segment's address
 
 	/* Set SOP and EOP */
 	segment->hw.control |= XILINX_DMA_BD_SOP;
@@ -1035,9 +1100,22 @@ static struct dma_async_tx_descriptor *xilinx_dma_prep_dma_cyclic(
 			struct xilinx_dma_desc_hw *hw;
 
 			/* Get a free segment */
-			segment = xilinx_dma_alloc_tx_segment(chan);
-			if (!segment)
-				goto error;
+			{
+				struct xilinx_dma_tx_segment *prev_segment = segment;
+
+				segment = xilinx_dma_alloc_tx_segment(chan);
+				if (!segment)
+					goto error;
+
+				if ( prev_segment ) {   // link prev -> current
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+					prev_segment->hw.next_desc_msb = upper_32_bits(segment->phys);
+					prev_segment->hw.next_desc     = lower_32_bits(segment->phys);
+#else
+					prev_segment->hw.next_desc = segment->phys;
+#endif
+				}
+			}
 
 			/*
 			 * Calculate the maximum number of bytes to transfer,
@@ -1067,8 +1145,20 @@ static struct dma_async_tx_descriptor *xilinx_dma_prep_dma_cyclic(
 		}
 	}
 
-	segment = list_first_entry(&desc->segments,
-				   struct xilinx_dma_tx_segment, node);
+	{
+		struct xilinx_dma_tx_segment *last_segment = segment;
+
+		segment = list_first_entry(&desc->segments,
+					   struct xilinx_dma_tx_segment, node);
+		/* Link last segment to first */
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+		last_segment->hw.next_desc     = lower_32_bits(segment->phys);
+		last_segment->hw.next_desc_msb = upper_32_bits(segment->phys);
+#else
+		last_segment->hw.next_desc = segment->phys;
+#endif
+	}
+
 	desc->async_tx.phys = segment->phys;
 	desc->cyclic = true;
 	chan->ctrl_reg |= XILINX_DMA_CR_CYCLIC_BD_EN_MASK;
@@ -1219,7 +1309,6 @@ static int xilinx_dma_chan_probe(struct xilinx_dma_device *xdev,
 	INIT_LIST_HEAD(&chan->pending_list);
 	INIT_LIST_HEAD(&chan->done_list);
 	INIT_LIST_HEAD(&chan->active_list);
-	INIT_LIST_HEAD(&chan->free_seg_list);
 
 	chan->common.device = &xdev->common;
 

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -71,6 +71,7 @@
 #define XILINX_DMA_BD_STS_ALL_MASK	GENMASK(31, 28)
 #define XILINX_DMA_BD_SOP		BIT(27)
 #define XILINX_DMA_BD_EOP		BIT(26)
+#define XILINX_DMA_BD_CMPLT		BIT(31)
 
 /* Hw specific definitions */
 #define XILINX_DMA_MAX_CHANS_PER_DEVICE	0x2
@@ -81,7 +82,6 @@
 
 /* Maximum number of Descriptors */
 #define XILINX_DMA_NUM_DESCS		255
-#define XILINX_DMA_COALESCE_MAX		255
 #define XILINX_DMA_NUM_APP_WORDS	5
 
 #define xilinx_dma_poll_timeout(chan, reg, val, cond, delay_us, timeout_us) \
@@ -160,7 +160,6 @@ struct xilinx_dma_tx_descriptor {
  * @err: Channel has errors
  * @tasklet: Cleanup work after irq
  * @residue: Residue
- * @desc_pendingcount: Descriptor pending count
  */
 struct xilinx_dma_chan {
 	struct xilinx_dma_device *xdev;
@@ -183,7 +182,6 @@ struct xilinx_dma_chan {
 	bool idle;
 	struct tasklet_struct tasklet;
 	u32 residue;
-	u32 desc_pendingcount;
 };
 
 /**
@@ -630,12 +628,9 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 	tail_segment = list_last_entry(&tail_desc->segments,
 				       struct xilinx_dma_tx_segment, node);
 
-	if (chan->desc_pendingcount <= XILINX_DMA_COALESCE_MAX) {
-		chan->ctrl_reg &= ~XILINX_DMA_CR_COALESCE_MAX;
-		chan->ctrl_reg |= chan->desc_pendingcount <<
-				  XILINX_DMA_CR_COALESCE_SHIFT;
-		dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
-	}
+	chan->ctrl_reg &= ~XILINX_DMA_CR_COALESCE_MAX;
+	chan->ctrl_reg |= 1 << XILINX_DMA_CR_COALESCE_SHIFT;    // setting IrqThreshold != 1 is unreliable
+	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 
 	if (chan->has_sg)
 #ifdef CONFIG_PHYS_ADDR_T_64BIT
@@ -679,7 +674,6 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 	}
 
 	list_splice_tail_init(&chan->pending_list, &chan->active_list);
-	chan->desc_pendingcount = 0;
 	chan->idle = false;
 }
 
@@ -705,14 +699,27 @@ static void xilinx_dma_complete_descriptor(struct xilinx_dma_chan *chan)
 {
 	struct xilinx_dma_tx_descriptor *desc, *next;
 
-	if (list_empty(&chan->active_list))
-		return;
 
 	list_for_each_entry_safe(desc, next, &chan->active_list, node) {
+
+		/* Check whether the last segment in this descriptor has been completed. */
+		const struct xilinx_dma_tx_segment * const tail_segment = 
+			list_last_entry(&desc->segments, struct xilinx_dma_tx_segment, node);
+
+		if ( ! (tail_segment->hw.status & XILINX_DMA_BD_CMPLT) )
+			break;  // we've processed all the completed descriptors so far
+		// If we get here, this descriptor has been completed
 		list_del(&desc->node);
+
 		if (!desc->cyclic)
 			dma_cookie_complete(&desc->async_tx);
+
 		list_add_tail(&desc->node, &chan->done_list);
+	}
+
+	if (list_empty(&chan->active_list)) {
+		chan->idle = true;
+		xilinx_dma_start_transfer(chan);
 	}
 }
 
@@ -789,8 +796,6 @@ static irqreturn_t xilinx_dma_irq_handler(int irq, void *data)
 	if (status & XILINX_DMA_XR_IRQ_IOC_MASK) {
 		spin_lock(&chan->lock);
 		xilinx_dma_complete_descriptor(chan);
-		chan->idle = true;
-		xilinx_dma_start_transfer(chan);
 		spin_unlock(&chan->lock);
 	}
 
@@ -839,13 +844,6 @@ static void append_desc_queue(struct xilinx_dma_chan *chan,
 	 */
 append:
 	list_add_tail(&desc->node, &chan->pending_list);
-	chan->desc_pendingcount++;
-
-	if (unlikely(chan->desc_pendingcount > XILINX_DMA_COALESCE_MAX)) {
-		dev_dbg(chan->dev, "desc pendingcount is too high\n");
-		chan->desc_pendingcount = XILINX_DMA_COALESCE_MAX;
-		BUG();
-	}
 }
 
 /**
@@ -981,14 +979,12 @@ static struct dma_async_tx_descriptor *xilinx_dma_prep_slave_sg(
 				   struct xilinx_dma_tx_segment, node);
 	desc->async_tx.phys = segment->phys;
 
-	/* For the last DMA_MEM_TO_DEV transfer, set EOP */
-	if (direction == DMA_MEM_TO_DEV) {
-		segment->hw.control |= XILINX_DMA_BD_SOP;
-		segment = list_last_entry(&desc->segments,
-					  struct xilinx_dma_tx_segment,
-					  node);
-		segment->hw.control |= XILINX_DMA_BD_EOP;
-	}
+	/* Set SOP and EOP */
+	segment->hw.control |= XILINX_DMA_BD_SOP;
+	segment = list_last_entry(&desc->segments,
+				struct xilinx_dma_tx_segment,
+				node);
+	segment->hw.control |= XILINX_DMA_BD_EOP;
 
 	return &desc->async_tx;
 
@@ -1162,7 +1158,6 @@ static int xilinx_dma_chan_probe(struct xilinx_dma_device *xdev,
 	chan->dev = xdev->dev;
 	chan->xdev = xdev;
 	chan->has_sg = xdev->has_sg;
-	chan->desc_pendingcount = 0x0;
 
 	has_dre = of_property_read_bool(node, "xlnx,include-dre");
 

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -778,7 +778,7 @@ static irqreturn_t xilinx_dma_irq_handler(int irq, void *data)
 	if (status & XILINX_DMA_XR_IRQ_ERROR_MASK) {
 		dev_err(chan->dev,
 			"Channel %p has errors %x cdr %x cdr msb %x tdr %x tdr msb %x",
-			chan, dma_ctrl_read(chan, XILINX_DMA_REG_STATUS),
+			chan, status,
 			dma_ctrl_read(chan, XILINX_DMA_REG_CURDESC),
 			dma_ctrl_read(chan, XILINX_DMA_REG_CURDESCMSB),
 			dma_ctrl_read(chan, XILINX_DMA_REG_TAILDESC),


### PR DESCRIPTION
I've sent the following to git@xilinx.com.  Posting here on github as well for the sake of open discussion.  It would be nice if in the future Xilinx could set up a subscribable mailing list that would allow patches to be discussed in the open.

---

Hello,

This patch series addresses a number of issues I discovered while using the
latest xilinx_dma.c driver in my Zynq project.  Changes were tested with both
S2MM and MM2S AXI DMA cores.

A number of issues are addressed, but the two most significant are:
1. Removal of incorrect interrupt coalescing code.
   - See also the discussion on the Xilinx forums at [1].
2. Re-introduction of a dma_pool for segments.
   - "Segments" are also referred to as "Buffer Descriptors in Xilinx PG021.
   - My application requires more than 255 descriptors at any given time.
   - The approach used here eliminates the 255 limitation without requiring
     the DMA to be halted and re-started when new segments are issued to the
     hardware.

I also found that under some circumstances, even with IrqThreshold set to 1, it
is possible to "miss" the interrupt for the last-issued segment (the segment
which is pointed to by the TAILDESC register), causing the driver to "hang" in
a state where all outstanding buffer descriptors have been processed by the
hardware (and thus no additional interrupts are coming), but software doesn't
know that, and thus will never issue future segments to the hardware.

The only way I saw to get around this issue without compromising throughput was
to implement periodic re-polling from within software using a kernel timer.

[1] https://forums.xilinx.com/t5/Embedded-Processor-System-Design/AXI-DMA-IrqThreshold-Clarification/td-p/671737

Regards,
Jeremy Trimble
