### PR TITLE
dmaengine: xilinx_dma: autodetect whether the HW supports scatter-gather

### DIFF
--- a/Documentation/devicetree/bindings/dma/xilinx/xilinx_dma.txt
+++ b/Documentation/devicetree/bindings/dma/xilinx/xilinx_dma.txt
@@ -11,10 +11,6 @@ Required properties:
 	two channels per device. This node specifies the properties of each
 	DMA channel (see child node properties below).
 
-Optional properties:
-- xlnx,include-sg: Tells whether configured for Scatter-mode in
-	the hardware.
-
 Required child node properties:
 - compatible: It should be either "xlnx,axi-dma-mm2s-channel" or
 	"xlnx,axi-dma-s2mm-channel".


### PR DESCRIPTION
The HW can be either direct-access or scatter-gather version. These are
SW incompatible.

The driver can handle both version: a DT propriety was used to
tell the driver whether to assume the HW is is scatter-gather mode.

This patch makes the driver to autodetect this information. The DT
propriety is not required anymore.

Signed-off-by: Andrea Merello andrea.merello@gmail.com
