### PR TITLE
do not ack level irqs in enable_or_unmask

### DIFF
--- a/drivers/irqchip/irq-xilinx-intc.c
+++ b/drivers/irqchip/irq-xilinx-intc.c
@@ -76,14 +76,6 @@ static void intc_enable_or_unmask(struct irq_data *d)
 
 	pr_debug("enable_or_unmask: %ld\n", d->hwirq);
 
-	/*
-	 * ack level irqs because they can't be acked during
-	 * ack function since the handle_level_irq function
-	 * acks the irq before calling the interrupt handler
-	 */
-	if (irqd_is_level_type(d))
-		local_intc->write_fn(mask, local_intc->baseaddr + IAR);
-
 	local_intc->write_fn(mask, local_intc->baseaddr + SIE);
 }
 


### PR DESCRIPTION
Acknowledging level IRQs in enable_or_unmask causes a race condition because the interrupt handler may have caused the interrupt to be re-activated. The interrupt framework already has mask_ack() and ack() calls, which are the proper places for interrupts to be acknowledged.

This commit removes the extra ack from intc_enable_or_unmask(), fixing the problem I was having with lost interrupts.
