### PR TITLE
Fix interrupt flags for Zynq in gpio_keys.c

### DIFF
--- a/drivers/input/keyboard/gpio_keys.c
+++ b/drivers/input/keyboard/gpio_keys.c
@@ -497,7 +497,16 @@ static int gpio_keys_setup_key(struct platform_device *pdev,
 		INIT_DELAYED_WORK(&bdata->work, gpio_keys_gpio_work_func);
 
 		isr = gpio_keys_gpio_isr;
+
+
+#ifndef CONFIG_ARCH_ZYNQ
 		irqflags = IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING;
+#else
+/*
+ * Zynq does not support IRQF_TRIGGER_FALLING, so we set only rising
+*/
+		irqflags = IRQF_TRIGGER_RISING;	
+#endif
 
 	} else {
 		if (!button->irq) {


### PR DESCRIPTION
Zynq A9 does not support falling edge interrupts.
gpio_keys.c sets irqflags regardless of what is set in the dts file to

irqflags = IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING

Later on kernel checks the flags in

kernle/irq/manage.c

and rejects setting the flags to IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING.

There might be a better way to fix it (e.g. make dts entry to get through) but I do not know how :-)
