### PR TITLE
RFT: xilinx_dma: fixes and improvement collection

### DIFF
--- a/Documentation/devicetree/bindings/dma/xilinx/xilinx_dma.txt
+++ b/Documentation/devicetree/bindings/dma/xilinx/xilinx_dma.txt
@@ -12,8 +12,6 @@ Required properties:
 	DMA channel (see child node properties below).
 
 Optional properties:
-- xlnx,include-sg: Tells whether configured for Scatter-mode in
-	the hardware.
 - xlnx,multichannel-dma: Tells whether configured for multi-channel
 	mode in the hardware.
 

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -806,6 +806,7 @@ static int xilinx_dma_chan_reset(struct xilinx_dma_chan *chan)
 	}
 
 	chan->err = false;
+	chan->idle = true;
 
 	return err;
 }
@@ -1263,6 +1264,9 @@ static int xilinx_dma_terminate_all(struct dma_chan *dchan)
 
 	/* Halt the DMA engine */
 	xilinx_dma_halt(chan);
+
+	if (chan->err)
+		xilinx_dma_chan_reset(chan);
 
 	/* Remove and free all of the descriptors in the lists */
 	xilinx_dma_free_descriptors(chan);

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -833,7 +833,7 @@ static irqreturn_t xilinx_dma_irq_handler(int irq, void *data)
 	if (status & XILINX_DMA_XR_IRQ_ERROR_MASK) {
 		dev_err(chan->dev,
 			"Channel %p has errors %x cdr %x cdr msb %x tdr %x tdr msb %x",
-			chan, dma_ctrl_read(chan, XILINX_DMA_REG_STATUS),
+			chan, status,
 			dma_ctrl_read(chan, XILINX_DMA_REG_CURDESC),
 			dma_ctrl_read(chan, XILINX_DMA_REG_CURDESCMSB),
 			dma_ctrl_read(chan, XILINX_DMA_REG_TAILDESC),

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -697,15 +697,15 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 	if (chan->has_sg && chan->mcdma) {
 		if (head_desc->direction == DMA_MEM_TO_DEV) {
 			dma_ctrl_write(chan, XILINX_DMA_REG_CURDESC,
-				       head_desc->async_tx.phys);
+				       head_seg_phys);
 		} else {
 			if (!config->tdest) {
 				dma_ctrl_write(chan, XILINX_DMA_REG_CURDESC,
-				       head_desc->async_tx.phys);
+				       head_seg_phys);
 			} else {
 				dma_ctrl_write(chan,
 					XILINX_DMA_MCRX_CDESC(config->tdest),
-				       head_desc->async_tx.phys);
+				       head_seg_phys);
 			}
 		}
 	}

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -1536,10 +1536,14 @@ static int xilinx_dma_channel_probe(struct xilinx_dma_device *xdev,
 				    struct device_node *node) {
 	int ret, i, nr_channels;
 
-	ret = of_property_read_u32(node, "dma-channels", &nr_channels);
-	if (ret) {
-		dev_err(xdev->dev, "unable to read dma-channels property");
-		return ret;
+	if (xdev->mcdma) {
+		ret = of_property_read_u32(node, "dma-channels", &nr_channels);
+		if (ret) {
+			dev_err(xdev->dev, "unable to read dma-channels property");
+			return ret;
+		}
+	} else {
+		nr_channels = 1;
 	}
 
 	xdev->nr_channels += nr_channels;

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -103,7 +103,7 @@
 			     ((aruser << 28) | (axcache << 24))
 
 #define xilinx_dma_poll_timeout(chan, reg, val, cond, delay_us, timeout_us) \
-	readl_poll_timeout(chan->xdev->regs + chan->ctrl_offset + reg, val, \
+	readl_poll_timeout_atomic(chan->xdev->regs + chan->ctrl_offset + reg, val, \
 			   cond, delay_us, timeout_us)
 
 /**

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -189,9 +189,7 @@ struct xilinx_dma_chan {
 	struct list_head done_list;
 	struct list_head active_list;
 	struct dma_chan common;
-	struct xilinx_dma_tx_segment *seg_v;
 	struct xilinx_mcdma_config config;
-	dma_addr_t seg_p;
 	struct device *dev;
 	int irq;
 	int id;
@@ -1386,7 +1384,6 @@ static int xilinx_dma_terminate_all(struct dma_chan *dchan)
 	/* clear isr for next time */
 	dma_ctrl_write(chan, XILINX_DMA_REG_STATUS,
 		       XILINX_DMA_XR_IRQ_ALL_MASK);
-
 
 	return 0;
 }

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -837,6 +837,8 @@ static int xilinx_dma_chan_reset(struct xilinx_dma_chan *chan)
 		return -EBUSY;
 	}
 
+	/* restore local copy with HW val after reset */
+	chan->ctrl_reg = dma_ctrl_read(chan, XILINX_DMA_REG_CONTROL);
 	chan->err = false;
 	chan->idle = true;
 

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -690,7 +690,6 @@ static void xilinx_dma_start_transfer(struct xilinx_dma_chan *chan)
 	chan->ctrl_reg |= 1 << XILINX_DMA_CR_COALESCE_SHIFT;    // setting IrqThreshold != 1 is unreliable
 	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 
-
 	if (chan->has_sg && !chan->mcdma) {
 		BUG_ON(head_seg_phys & 0x3F);
 #ifdef CONFIG_PHYS_ADDR_T_64BIT
@@ -781,8 +780,10 @@ static void xilinx_dma_issue_pending(struct dma_chan *dchan)
 	struct xilinx_dma_chan *chan = to_xilinx_chan(dchan);
 	unsigned long flags;
 
-	/* Enable interrupts */
-	chan->ctrl_reg |= XILINX_DMA_XR_IRQ_ALL_MASK;
+	/* Config and Enable interrupts (note: setting IrqThreshold != 1 is unreliable) */
+	chan->ctrl_reg &= ~XILINX_DMA_CR_COALESCE_MAX;
+	chan->ctrl_reg |= 1 << XILINX_DMA_CR_COALESCE_SHIFT |
+		XILINX_DMA_XR_IRQ_ALL_MASK;
 	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 
 	spin_lock_irqsave(&chan->lock, flags);

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -600,6 +600,8 @@ static void xilinx_dma_halt(struct xilinx_dma_chan *chan)
 		dev_err(chan->dev, "Cannot stop channel %p: %x\n",
 			chan, dma_ctrl_read(chan, XILINX_DMA_REG_STATUS));
 		chan->err = true;
+	} else {
+		chan->idle = true;
 	}
 }
 

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -391,9 +391,9 @@ static int xilinx_dma_alloc_chan_resources(struct dma_chan *dchan)
 
 	dma_cookie_init(dchan);
 
-	/* Enable interrupts */
-	chan->ctrl_reg |= XILINX_DMA_XR_IRQ_ALL_MASK;
-	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
+	/* clear isr reg */
+	dma_ctrl_write(chan, XILINX_DMA_REG_STATUS,
+		       XILINX_DMA_XR_IRQ_ALL_MASK);
 
 	return 0;
 }
@@ -772,6 +772,10 @@ static void xilinx_dma_issue_pending(struct dma_chan *dchan)
 {
 	struct xilinx_dma_chan *chan = to_xilinx_chan(dchan);
 	unsigned long flags;
+
+	/* Enable interrupts */
+	chan->ctrl_reg |= XILINX_DMA_XR_IRQ_ALL_MASK;
+	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 
 	spin_lock_irqsave(&chan->lock, flags);
 	xilinx_dma_start_transfer(chan);
@@ -1349,6 +1353,10 @@ static int xilinx_dma_terminate_all(struct dma_chan *dchan)
 {
 	struct xilinx_dma_chan *chan = to_xilinx_chan(dchan);
 
+	/* Disable interrupts */
+	chan->ctrl_reg &= ~XILINX_DMA_XR_IRQ_ALL_MASK;
+	dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
+
 	/* Halt the DMA engine */
 	xilinx_dma_halt(chan);
 
@@ -1364,6 +1372,11 @@ static int xilinx_dma_terminate_all(struct dma_chan *dchan)
 		dma_ctrl_write(chan, XILINX_DMA_REG_CONTROL, chan->ctrl_reg);
 		chan->cyclic = false;
 	}
+
+	/* clear isr for next time */
+	dma_ctrl_write(chan, XILINX_DMA_REG_STATUS,
+		       XILINX_DMA_XR_IRQ_ALL_MASK);
+
 
 	return 0;
 }

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -1350,6 +1350,8 @@ static int xilinx_dma_terminate_all(struct dma_chan *dchan)
 	/* Halt the DMA engine */
 	xilinx_dma_halt(chan);
 
+	tasklet_kill(&chan->tasklet);
+
 	if (chan->err)
 		xilinx_dma_chan_reset(chan);
 

--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -429,6 +429,7 @@ static void xilinx_dma_free_descriptors(struct xilinx_dma_chan *chan)
 	spin_unlock_irqrestore(&chan->lock, flags);
 }
 
+static int xilinx_dma_terminate_all(struct dma_chan *dchan);
 /**
  * xilinx_dma_free_chan_resources - Free channel resources
  * @dchan: DMA channel
@@ -441,7 +442,7 @@ static void xilinx_dma_free_chan_resources(struct dma_chan *dchan)
 	struct dma_pool *pool_to_free = NULL;
 	struct xilinx_dma_tx_segment *seg_to_free = NULL;
 
-	xilinx_dma_free_descriptors(chan);
+	xilinx_dma_terminate_all(&chan->common);
 
 	/* Free memory that was allocated for the segments (from non-atomic context) */
 	spin_lock_irqsave(&chan->lock, flags);


### PR DESCRIPTION
This is a rebase onto latest xilinx_dma driver of patches I have on my local tree. It includes:
- Selected patches from @jeremytrimble #76 pull-request
- Various fixes by me

I tested this with the test client, and I used this before rebasing with our own IPs, with SG in both directions. Unfortunately I've not any chance to test cyclic and interleaved mode; this is why the "RFT".
