### PR TITLE
char: xdevcfg: remove unneeded PCFG_PROG_B assertion

### DIFF
--- a/drivers/char/xilinx_devcfg.c
+++ b/drivers/char/xilinx_devcfg.c
@@ -174,13 +174,6 @@ static void xdevcfg_reset_pl(void __iomem *base_address)
 	 * the rising edge happens.
 	 */
 	xdevcfg_writereg(base_address + XDCFG_CTRL_OFFSET,
-			(xdevcfg_readreg(base_address + XDCFG_CTRL_OFFSET) |
-			 XDCFG_CTRL_PCFG_PROG_B_MASK));
-	while (!(xdevcfg_readreg(base_address + XDCFG_STATUS_OFFSET) &
-				XDCFG_STATUS_PCFG_INIT_MASK))
-		;
-
-	xdevcfg_writereg(base_address + XDCFG_CTRL_OFFSET,
 			(xdevcfg_readreg(base_address + XDCFG_CTRL_OFFSET) &
 			 ~XDCFG_CTRL_PCFG_PROG_B_MASK));
 	while (xdevcfg_readreg(base_address + XDCFG_STATUS_OFFSET) &


### PR DESCRIPTION
PCFG_PROG_B is already 1, so asserting it here will not generate
a edge. If the PL is not correctly loaded before, waiting for
PCFG_INIT will wait forever.
