### PR TITLE
gpio-xilinx.c: Fix irq-handler prototype

### DIFF
--- a/drivers/gpio/gpio-xilinx.c
+++ b/drivers/gpio/gpio-xilinx.c
@@ -347,8 +347,10 @@ static int xgpio_to_irq(struct gpio_chip *gc, unsigned offset)
  * @irq: gpio irq number
  * @desc: Pointer to interrupt description
  */
-static void xgpio_irqhandler(unsigned int irq, struct irq_desc *desc)
+static void xgpio_irqhandler(struct irq_desc *desc)
 {
+	unsigned int irq = irq_desc_get_irq(desc);
+
 	struct xgpio_instance *chip = (struct xgpio_instance *)
 						irq_get_handler_data(irq);
 	struct of_mm_gpio_chip *mm_gc = &chip->mmchip;


### PR DESCRIPTION
Updated irq-handler to correspond to the prototype change of patch bd0b9ac405e1794d72533c3d487aa65b6b955a0c.

Signed-off-by: Topi Kuutela <topi.kuutela@murata.com>