### PR TITLE
dma: xilinx: use readl_poll_timeout_atomic instead of readl_poll_timeout

### DIFF
--- a/drivers/dma/xilinx/xilinx_dma.c
+++ b/drivers/dma/xilinx/xilinx_dma.c
@@ -103,8 +103,8 @@
 			     ((aruser << 28) | (axcache << 24))
 
 #define xilinx_dma_poll_timeout(chan, reg, val, cond, delay_us, timeout_us) \
-	readl_poll_timeout(chan->xdev->regs + chan->ctrl_offset + reg, val, \
-			   cond, delay_us, timeout_us)
+	readl_poll_timeout_atomic(chan->xdev->regs + chan->ctrl_offset + reg, val, \
+				  cond, delay_us, timeout_us)
 
 /**
  * struct xilinx_dma_desc_hw - Hardware Descriptor


### PR DESCRIPTION
The xilinx_dma_poll_timeout macro is sometimes called while holding a
spinlock (see xilinx_dma_issue_pending() for an example) this means we
shouldn't sleep when polling the dma channel registers.

Signed-off-by: Marc Ferland ferlandm@amotus.ca
