### PR TITLE
ARM: zynq: Fix secondary CPU startup / suspend in Thumb2 kernel

### DIFF
--- a/arch/arm/mach-zynq/headsmp.S
+++ b/arch/arm/mach-zynq/headsmp.S
@@ -10,6 +10,7 @@
 #include <linux/init.h>
 #include <asm/assembler.h>
 
+.arm
 ENTRY(zynq_secondary_trampoline)
 ARM_BE8(setend	be)				@ ensure we are in BE8 mode
 	ldr	r0, zynq_secondary_trampoline_jump

--- a/arch/arm/mach-zynq/platsmp.c
+++ b/arch/arm/mach-zynq/platsmp.c
@@ -41,7 +41,12 @@ int zynq_cpun_start(u32 address, int cpu)
 
 	/* MS: Expectation that SLCR are directly map and accessible */
 	/* Not possible to jump to non aligned address */
+	/* Address LSB decides execution mode: 0 for ARM, 1 for Thumb2 */
+#ifndef CONFIG_THUMB2_KERNEL
 	if (!(address & 3) && (!address || (address >= trampoline_code_size))) {
+#else
+	if (!((address & 3) ^ 1) && (!address || (address >= trampoline_code_size))) {
+#endif
 		/* Store pointer to ioremap area which points to address 0x0 */
 		static u8 __iomem *zero;
 		u32 trampoline_size = &zynq_secondary_trampoline_jump -

--- a/arch/arm/mach-zynq/suspend.S
+++ b/arch/arm/mach-zynq/suspend.S
@@ -36,6 +36,7 @@
 #define DDRC_OPMODE_SR		3
 #define MAXTRIES		100
 
+	.arm
 	.text
 
 /**


### PR DESCRIPTION
The secondary CPU starts up in ARM mode, so we have to tell the compiler about this fact in the secondary startup trampoline. Done this also in suspend code.

Additionally, the check performed on the jump address ignored that the LSB in Thumb2 mode is 1.
