### PR TITLE
Fix bug of function 'drm_encoder_init' call

### DIFF
--- a/drivers/gpu/drm/xylon/xylon_encoder.c
+++ b/drivers/gpu/drm/xylon/xylon_encoder.c
@@ -170,7 +170,7 @@ struct drm_encoder *xylon_drm_encoder_create(struct drm_device *dev)
 	encoder->slave.base.possible_crtcs = 1;
 	ret = drm_encoder_init(dev, &encoder->slave.base,
 			       &xylon_drm_encoder_funcs,
-			       DRM_MODE_ENCODER_TMDS);
+			       DRM_MODE_ENCODER_TMDS, NULL);
 	if (ret) {
 		DRM_ERROR("failed initialize encoder\n");
 		return ERR_PTR(ret);


### PR DESCRIPTION
When I tried to compile the kernel with zynq_zed configuration file and gcc5.2.0, I got these error messages: 

"drivers/gpu/drm/xylon/xylon_encoder.c: In function 'xylon_drm_encoder_create':
drivers/gpu/drm/xylon/xylon_encoder.c:173:11: error: too few arguments to function 'drm_encoder_init'
include/drm/drm_crtc.h:2282:5: note: declared here
scripts/Makefile.build:291: recipe for target 'drivers/gpu/drm/xylon/xylon_encoder.o' failed
make[4]: **\* [drivers/gpu/drm/xylon/xylon_encoder.o] Error 1
scripts/Makefile.build:440: recipe for target 'drivers/gpu/drm/xylon' failed
make[3]: **\* [drivers/gpu/drm/xylon] Error 2
scripts/Makefile.build:440: recipe for target 'drivers/gpu/drm' failed
make[2]: **\* [drivers/gpu/drm] Error 2
scripts/Makefile.build:440: recipe for target 'drivers/gpu' failed
make[1]: **\* [drivers/gpu] Error 2
Makefile:959: recipe for target 'drivers' failed
make: **\* [drivers] Error 2
"
After checking, I found this bug, fix it by add an extra param "NULL", then the kernel build pass.
