### PR TITLE
spi-xilinx.c: correct multibyte writes

### DIFF
--- a/drivers/spi/spi-xilinx.c
+++ b/drivers/spi/spi-xilinx.c
@@ -152,7 +152,7 @@ static void xspi_fill_tx_fifo_##size(struct xilinx_spi *xqspi)		\
 	u32 data = 0;							\
 	for (i = 0; i < count; i += (size/8)) {				\
 		if (xqspi->tx_ptr)					\
-			data = (type)((u8 *)xqspi->tx_ptr)[i];		\
+			data = *(type *)&xqspi->tx_ptr[i];		\
 		writel_relaxed(data, (xqspi->regs + XSPI_TXD_OFFSET));	\
 	}								\
 	xqspi->bytes_to_transfer -= count;				\


### PR DESCRIPTION
When bits-per-word is greater than 8 only the first byte is sent; this
is caused by an incorrect cast in the macros used to fill the tx fifo.