### PR TITLE
pl35x_nand: Add dsb(st) (store-only data sync barrier) after reg writes

### DIFF
--- a/drivers/mtd/nand/pl35x_nand.c
+++ b/drivers/mtd/nand/pl35x_nand.c
@@ -788,6 +788,12 @@ static void pl35x_nand_cmd_function(struct mtd_info *mtd, unsigned int command,
 
 	pl35x_nand_write32(cmd_addr, cmd_data);
 
+	/*
+	 * Ensure writes to the command register are observed by chip
+	 * before proceeding to ndelay() and other reads/writes.
+	 */
+	dsb(st);
+
 	if (curr_cmd->end_cmd_valid) {
 		xnand->end_cmd = curr_cmd->end_cmd;
 		xnand->end_cmd_pending = 1;


### PR DESCRIPTION
Add dsb(st) [1] after writes to command register to ensure the chip
receives them before ndelay()-ing to synchronize driver/chip state.

The subsequent ndelay()s (after dsb(st)) gives the chip enough time to
process "quick" commands (like RNDOUT) which don't change status flags
or issue interrupts upon completion. They are assumed to complete at
most 100ns after delivery on the bus. It's therefore critical to ensure
they make it all the way down to the chip before the driver ndelay()s
for on-chip processing. Otherwise, commands may get buffered in the
interconnect between the CPU and chip while the driver waits. Subsequent
read/write operations may then be delivered inside the on-chip
processing window resulting in incorrect behavior.

In particular, a READ0 (page select + col change), followed by RNDOUT
(column change only), followed by data reads <1page in size results in
sporadic one-byte data corruption, particularity when the bus is busy.

Testing:

No longer see a sporadic 1 byte corruption after RNDOUT by repeatedly
reading the entire Linux file system after fs-cache drop for 48 hours.

Verified RNDOUT requires the ndelay() by unsuccessfully attempting to
remove it for that command. Doing so results in the same sporadic 1 byte
corruption in the aforementioned read test.

Ran fio [2] with random read/write+verify for 48 hours; no corruptions
reported. Config: rw=randrw, size=100M, bs=5k, verify=sha256, numjobs=5

Hardware:
 National Instruments cRIO-9068 [3]
  Xilinx Zynq-7020 SoC
  MT29F8G08ADBDAH4 8GB NAND

[1] http://infocenter.arm.com/help/topic/com.arm.doc.dui0489c/CIHGHHIE.html#id4692433
[2] http://linux.die.net/man/1/fio
[3] https://sine.ni.com/nips/cds/view/p/lang/en/nid/211620

Signed-off-by: Haris Okanovic <haris.okanovic@ni.com>
Reviewed-by: Brad Mouring <brad.mouring@ni.com>
Reviewed-by: Jeff Westfahl <jeff.westfahl@ni.com>