### PR TITLE
Fix zynqmp pll disable (clkc)

### DIFF
--- a/drivers/clk/zynqmp/pll.c
+++ b/drivers/clk/zynqmp/pll.c
@@ -279,10 +279,18 @@ static int zynqmp_pll_enable(struct clk_hw *hw)
  */
 static void zynqmp_pll_disable(struct clk_hw *hw)
 {
+        u32 reg;
 	struct zynqmp_pll *clk = to_zynqmp_pll(hw);
 
 	if (!zynqmp_pll_is_enabled(hw))
 		return;
+
+        /* Must assert BYPASS before asserting Reset - UG1087 (v1.2) */
+	reg = zynqmp_pm_mmio_readl(clk->pll_ctrl);
+        if (!(reg & PLLCTRL_BP_MASK)) {
+           reg |= PLLCTRL_BP_MASK;
+           zynqmp_pm_mmio_writel(reg, clk->pll_ctrl);
+        }
 
 	pr_info("PLL: shutdown\n");
 


### PR DESCRIPTION
We noticed that linux would fail during boot in the routine zynqmp_pll_disable (drivers/clk/zynqmp/pll.c).  Upon reading the ultrascale+ MPSOC Register Reference for the VPLL_CTRL (CRF_APB) Register, it was discovered that the RESET flag can only be asserted if the PLL is already in BYPASS.  This pull request adds a check of the BYPASS bit and asserts it if not asserted - before asserting the RESET bit.