### PR TITLE
iio XADC issue

### DIFF
--- a/drivers/iio/adc/xilinx-xadc-core.c
+++ b/drivers/iio/adc/xilinx-xadc-core.c
@@ -772,8 +772,7 @@ static int xadc_get_seq_mode(struct xadc *xadc, unsigned long scan_mode)
 	if (xadc->external_mux_mode == XADC_EXTERNAL_MUX_DUAL)
 		return XADC_CONF1_SEQ_SIMULTANEOUS;
 
-	if ((aux_scan_mode & 0xff00) == 0 ||
-		(aux_scan_mode & 0x00ff) == 0)
+	if (aux_scan_mode & 0xff00)
 		return XADC_CONF1_SEQ_CONTINUOUS;
 
 	return XADC_CONF1_SEQ_SIMULTANEOUS;


### PR DESCRIPTION
it seems the driver can set the XADC hardware into simultaneous when it shouldn't be ... for example if vaux15 and vaux4 are set to be read it would go into simultaneous mode but as only the lower byte is used of Sequencer Register 1 vaux15 will not be read

see xilinx UG480  Table 4-4 (pg. 60)
![image](https://cloud.githubusercontent.com/assets/10204013/26474219/025ecde4-416d-11e7-9082-ed3078d0dbea.png)

