### PR TITLE
Nand pl35x

### DIFF
--- a/drivers/mtd/nand/pl35x_nand.c
+++ b/drivers/mtd/nand/pl35x_nand.c
@@ -582,7 +582,7 @@ static int pl35x_nand_write_page_swecc(struct mtd_info *mtd,
 	u32 ret;
 
 	for (i = 0; eccsteps; eccsteps--, i += eccbytes, p += eccsize)
-		chip->ecc.calculate(mtd, p, &ecc_calc[0]);
+		chip->ecc.calculate(mtd, p, &ecc_calc[i]);
 
 	ret = mtd_ooblayout_set_eccbytes(mtd, ecc_calc, chip->oob_poi,
 						0, chip->ecc.total);


### PR DESCRIPTION
Hello,

The pl35x-nand driver makes an amazing assumption that ioremap will always return addresses that do not set bits 0-23. Please pull these changes to linux-xlnx/master so that the pl35x-nand will work as expected all the time.

Unrelated, I also spotted a typo in the swecc code and fixed that as well.

John Ogness