### PR TITLE
net: ethernet: xilinx: Fix tx after reopening driver

### DIFF
--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
@@ -2231,6 +2231,7 @@ static int axienet_open(struct net_device *ndev)
 	 * will be processed as only the NAPI function re-enables them!
 	 */
 			napi_enable(&lp->napi[i]);
+			netif_start_queue(ndev);
 		}
 		for_each_dma_queue(lp, i) {
 			struct axienet_dma_q *q = lp->dq[i];


### PR DESCRIPTION
When reopening the xilinx axienet driver after it has already been opened once, the tx is not being started anymore. This is because netif_stop_queue() was called when closing the driver, but not started when opening the driver.

This patch fixed this issue.