### PR TITLE
net: ethernet: xilinx: Apply DTS 'phy-mode' to phydev->interface

### DIFF
--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
@@ -2211,6 +2211,9 @@ static int axienet_open(struct net_device *ndev)
 			phy_start(phydev);
 	}
 
+	/* Apply configuration from DTS: 'phy-mode' */
+	ndev->phydev->interface = lp->phy_interface;
+
 	if (!lp->is_tsn || lp->temac_no == XAE_TEMAC1) {
 		/* Enable tasklets for Axi DMA error handling */
 		for_each_dma_queue(lp, i) {


### PR DESCRIPTION
'phy-mode' node value is stored in struct axienet_local during axienet_probe(). During axienet_open() it is not recalled so phydev use default value ignoring DTS selected one.