### PR TITLE
Add 6G ST435-1 standard for 4Kp30 and friends.

### DIFF
--- a/drivers/media/platform/xilinx/xilinx-sdirxss.c
+++ b/drivers/media/platform/xilinx/xilinx-sdirxss.c
@@ -212,6 +212,7 @@
 #define XST352_BYTE1_ST372_DL_3GB		0x8A
 #define XST352_BYTE1_ST372_2x720L_3GB		0x8B
 #define XST352_BYTE1_ST372_2x1080L_3GB		0x8C
+#define XST352_BYTE1_ST435_1_6G		0x90
 #define XST352_BYTE1_ST2081_10_2160L_6G		0xC0
 #define XST352_BYTE1_ST2081_10_DL_2160L_6G	0xC2
 #define XST352_BYTE1_ST2082_10_2160L_12G	0xCE
@@ -759,6 +760,8 @@ static int xsdirx_get_stream_properties(struct xsdirxss_state *state)
 		break;
 	case XSDIRX_MODE_6G_MASK:
 		switch (byte1) {
+		case XST352_BYTE1_ST435_1_6G:
+			/* SMPTE ST 435-1 */
 		case XST352_BYTE1_ST2081_10_DL_2160L_6G:
 			/* Dual link 6G */
 		case XST352_BYTE1_ST2081_10_2160L_6G:


### PR DESCRIPTION
The Blackmagic ATEM Production Studio 4K uses ST435-1 (byte1 == 0x90) for 4Kp30 and friends (29.97, 25, 24, 23.98). This modification enables that.