### PR TITLE
ARM: zynq: Fix spurious BUG with old DT

### DIFF
--- a/arch/arm/mach-zynq/efuse.c
+++ b/arch/arm/mach-zynq/efuse.c
@@ -33,6 +33,9 @@ bool zynq_efuse_cpu_state(int cpu)
 	if (!cpu)
 		return true;
 
+	if (!zynq_efuse_base)
+		return true;
+
 	state = readl(zynq_efuse_base + EFUSE_STATUS_OFFSET);
 	state &= EFUSE_STATUS_CPU_BIT;
 
@@ -56,13 +59,13 @@ int __init zynq_early_efuse_init(void)
 	np = of_find_compatible_node(NULL, NULL, "xlnx,zynq-efuse");
 	if (!np) {
 		pr_err("%s: no efuse node found\n", __func__);
-		BUG();
+		return -1;
 	}
 
 	zynq_efuse_base = of_iomap(np, 0);
 	if (!zynq_efuse_base) {
 		pr_err("%s: Unable to map I/O memory\n", __func__);
-		BUG();
+		return -1;
 	}
 
 	np->data = (__force void *)zynq_efuse_base;


### PR DESCRIPTION
Commit 78604f7bad89 ("ARM: zynq: Add support for Zynq-7000S devices")
introduced a new DT node to indicate how to access efuses on Zynq 7000
devices.

Unfortunately the code did not implement the case when that node does
not exist, which is quite common in EBBR like environments where device
trees get passed down from firmware.

So let's implement the error case properly and just not access the efuse
device if no DT node for it was passed in, restoring compatibility with
older device trees.

Fixes: 78604f7bad89 ("ARM: zynq: Add support for Zynq-7000S devices")
Signed-off-by: Alexander Graf <agraf@suse.de>