### PR TITLE
Fix Zynq SMP CPU start when kernel is built in Thumb2 mode

### DIFF
--- a/arch/arm/mach-zynq/headsmp.S
+++ b/arch/arm/mach-zynq/headsmp.S
@@ -10,6 +10,7 @@
 #include <linux/init.h>
 #include <asm/assembler.h>
 
+	.arm
 ENTRY(zynq_secondary_trampoline)
 ARM_BE8(setend	be)				@ ensure we are in BE8 mode
 	ldr	r0, zynq_secondary_trampoline_jump

--- a/arch/arm/mach-zynq/platsmp.c
+++ b/arch/arm/mach-zynq/platsmp.c
@@ -41,7 +41,7 @@ int zynq_cpun_start(u32 address, int cpu)
 
 	/* MS: Expectation that SLCR are directly map and accessible */
 	/* Not possible to jump to non aligned address */
-	if (!(address & 3) && (!address || (address >= trampoline_code_size))) {
+	if (!(address & 2) && (!address || (address >= trampoline_code_size))) {
 		/* Store pointer to ioremap area which points to address 0x0 */
 		static u8 __iomem *zero;
 		u32 trampoline_size = &zynq_secondary_trampoline_jump -


### PR DESCRIPTION
The secondary CPU will start in arm mode, so we need to set the startup code as arm encoding explicitly when the kernel is compiled with CONFIG_THUMB2_KERNEL. `bx` is valid on an address with the LSB set, so it shouldn't be checked.