### PR TITLE
mtd: spi-nor: Fix writing at the end of stacked

### DIFF
--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -1901,7 +1901,7 @@ static int spi_nor_write(struct mtd_info *mtd, loff_t to, size_t len,
 		if (nor->addr_width == 3)
 			write_ear(nor, offset);
 		if (nor->isstacked == 1) {
-			if (len <= rem_bank_len) {
+			if ((len - i) <= rem_bank_len) {
 				page_remain = min_t(size_t,
 					 nor->page_size - page_offset, len - i);
 			} else {


### PR DESCRIPTION
This fixes a bug where the flash nor chip (in stacked configuration) cannot be written correctly at the end.