### PR TITLE
add fractional multiplier usage

### DIFF
--- a/drivers/staging/clocking-wizard/clk-xlnx-clock-wizard.c
+++ b/drivers/staging/clocking-wizard/clk-xlnx-clock-wizard.c
@@ -25,14 +25,14 @@
 #define WZRD_CLKFBOUT_FRAC_EN	BIT(26)
 
 #define WZRD_CLKFBOUT_MULT_SHIFT	8
-#define WZRD_CLKFBOUT_MULT_MASK		(0xff << WZRD_CLKFBOUT_MULT_SHIFT)
+#define WZRD_CLKFBOUT_MULT_MASK		0xff
 #define WZRD_CLKFBOUT_FRAC_SHIFT	16
-#define WZRD_CLKFBOUT_FRAC_MASK		(0x3ff << WZRD_CLKFBOUT_FRAC_SHIFT)
+#define WZRD_CLKFBOUT_FRAC_MASK		0x3ff
 #define WZRD_DIVCLK_DIVIDE_SHIFT	0
-#define WZRD_DIVCLK_DIVIDE_MASK		(0xff << WZRD_DIVCLK_DIVIDE_SHIFT)
+#define WZRD_DIVCLK_DIVIDE_MASK		0xff
 #define WZRD_CLKOUT_DIVIDE_SHIFT	0
 #define WZRD_CLKOUT_DIVIDE_WIDTH	8
-#define WZRD_CLKOUT_DIVIDE_MASK		(0xff << WZRD_DIVCLK_DIVIDE_SHIFT)
+#define WZRD_CLKOUT_DIVIDE_MASK		0xff
 #define WZRD_CLKOUT_FRAC_SHIFT		8
 #define WZRD_CLKOUT_FRAC_MASK		0x3ff
 
@@ -255,8 +255,9 @@ static int clk_wzrd_dynamic_reconfig_f(struct clk_hw *hw, unsigned long rate,
 	f = (u32)(pre - (clockout0_div * 1000));
 	f = f & WZRD_CLKOUT_FRAC_MASK;
 
-	value = ((f << WZRD_CLKOUT_DIVIDE_WIDTH) | (clockout0_div &
-			WZRD_CLKOUT_DIVIDE_MASK));
+	value = (f << WZRD_CLKOUT_DIVIDE_WIDTH) |
+		((clockout0_div >> WZRD_CLKOUT_DIVIDE_SHIFT) &
+		 WZRD_CLKOUT_DIVIDE_MASK);
 
 	/* Set divisor and clear phase offset */
 	writel(value, div_addr);
@@ -541,10 +542,10 @@ static int clk_wzrd_probe(struct platform_device *pdev)
 	}
 
 	/* register multiplier */
-	reg = (readl(clk_wzrd->base + WZRD_CLK_CFG_REG(0)) &
-		     WZRD_CLKFBOUT_MULT_MASK) >> WZRD_CLKFBOUT_MULT_SHIFT;
-	reg_f = (readl(clk_wzrd->base + WZRD_CLK_CFG_REG(0)) &
-		     WZRD_CLKFBOUT_FRAC_MASK) >> WZRD_CLKFBOUT_FRAC_SHIFT;
+	reg = (readl(clk_wzrd->base + WZRD_CLK_CFG_REG(0)) >>
+	       WZRD_CLKFBOUT_MULT_SHIFT) & WZRD_CLKFBOUT_MULT_MASK;
+	reg_f = (readl(clk_wzrd->base + WZRD_CLK_CFG_REG(0)) >>
+		 WZRD_CLKFBOUT_FRAC_SHIFT) & WZRD_CLKFBOUT_FRAC_MASK;
 
 	mult = ((reg * 1000) + reg_f);
 	clk_name = kasprintf(GFP_KERNEL, "%s_mul", dev_name(&pdev->dev));
@@ -564,8 +565,8 @@ static int clk_wzrd_probe(struct platform_device *pdev)
 	}
 
 	/* register div */
-	reg = (readl(clk_wzrd->base + WZRD_CLK_CFG_REG(0)) &
-			WZRD_DIVCLK_DIVIDE_MASK) >> WZRD_DIVCLK_DIVIDE_SHIFT;
+	reg = (readl(clk_wzrd->base + WZRD_CLK_CFG_REG(0)) >>
+	       WZRD_DIVCLK_DIVIDE_SHIFT) & WZRD_DIVCLK_DIVIDE_MASK;
 	clk_name = kasprintf(GFP_KERNEL, "%s_mul_div", dev_name(&pdev->dev));
 	if (!clk_name) {
 		ret = -ENOMEM;

--- a/drivers/staging/clocking-wizard/dt-binding.txt
+++ b/drivers/staging/clocking-wizard/dt-binding.txt
@@ -14,6 +14,8 @@ Required properties:
  - clocks: Handle to input clock
  - clock-names: Tuple containing 'clk_in1' and 's_axi_aclk'
  - clock-output-names: Names for the output clocks
+ - set-vco-parent: When this is set the VCO rate will also
+		   be adjusted when setting clkout0
 
 Optional properties:
  - speed-grade: Speed grade of the device (valid values are 1..3)


### PR DESCRIPTION
Hello,

These changes allow the use of the fractional multiplier to help in generating an arbitrary frequency.

There is an added device tree tag 'set-vco-parent' that enables this. This takes advantage of the underlying CLK_SET_RATE_PARENT feature which allows the rate change operation to propagate up
to the clk's parent.

Instead of multiple fixed clocks there is single VCO clock that sits between the clocking wizard input and the output. This is the common clock that all the outputs use.

We are using this driver in our application and would like to get it merged into the mainline kernel at some point.

This is a first step to open up discussion.

thanks,
Paul


