### PR TITLE
Fix error checking conditional statement: axi gpio driver

### DIFF
--- a/drivers/gpio/gpio-xilinx.c
+++ b/drivers/gpio/gpio-xilinx.c
@@ -650,7 +650,7 @@ static int xgpio_of_probe(struct platform_device *pdev)
 
 	chip->clk = devm_clk_get(&pdev->dev, "s_axi_aclk");
 	if (IS_ERR(chip->clk)) {
-		if ((PTR_ERR(chip->clk) != -ENOENT) ||
+		if ((PTR_ERR(chip->clk) != -ENOENT) &&
 				(PTR_ERR(chip->clk) != -EPROBE_DEFER)) {
 			dev_err(&pdev->dev, "Input clock not found\n");
 			return PTR_ERR(chip->clk);


### PR DESCRIPTION
As previously pointed out by cdsteinkuehler "The error returned by devm_clk_get is always going to not match both -ENOENT and -EPROBE_DEFER. I believe the conditional on line 628 should be && instead of ||, so the conditional falls through if the returned value is either -ENOINT or -EPROBE_DEFER rather than ALWAYS failing with an error if devm_clk_get() fails."

The original comment can be found here: https://github.com/Xilinx/linux-xlnx/commit/3bbc2fda8018d067910eac153c1f30caa509828a#diff-7ed822e465bd34f40d59c46889f9ba55