### PR TITLE
usb: dwc3: fix a build error when CONFIG_PM is not set.

### DIFF
--- a/drivers/usb/dwc3/dwc3-of-simple.c
+++ b/drivers/usb/dwc3/dwc3-of-simple.c
@@ -689,9 +689,10 @@ static int __maybe_unused dwc3_of_simple_resume(struct device *dev)
 				clk_disable(simple->clks[i]);
 			return ret;
 		}
-
+#ifdef CONFIG_PM
 		/* Ask ULPI to turn ON Vbus */
 		dwc3_simple_vbus(simple->dwc, false);
+#endif
 	}
 
 	return 0;
@@ -721,9 +722,10 @@ static int __maybe_unused dwc3_of_simple_suspend(struct device *dev)
 	int			i;
 
 	if (!simple->wakeup_capable && !simple->dwc->is_d3) {
+#ifdef CONFIG_PM
 		/* Ask ULPI to turn OFF Vbus */
 		dwc3_simple_vbus(simple->dwc, true);
-
+#endif
 		/* Disable the clocks */
 		for (i = 0; i < simple->num_clocks; i++)
 			clk_disable(simple->clks[i]);


### PR DESCRIPTION
There is a build error when CONFIG_PM is not set:
dwc3-of-simple.c:544:3: error: implicit declaration of function
'dwc3_simple_vbus';

Since dwc3_simple_vbus is defined only when CONFIG_PM is set, it
should be invoked when CONFIG_PM is set.

Signed-off-by: zheng.wang <zheng.wang@calmcar.com>
Signed-off-by: yongtong.yao <yongtong.yao@calmcar.com>