### PR TITLE
usb: dwc3: xilinx: Register drvdata before registering regulator

### DIFF
--- a/drivers/usb/dwc3/dwc3-xilinx.c
+++ b/drivers/usb/dwc3/dwc3-xilinx.c
@@ -514,13 +514,13 @@ static int dwc3_xlnx_probe(struct platform_device *pdev)
 	priv_data->regs = regs;
 	priv_data->dev = dev;
 
+	platform_set_drvdata(pdev, priv_data);
+
 #ifdef CONFIG_PM
 	ret = dwc3_xlnx_register_regulator(dev, priv_data);
 	if (ret)
 		return ret;
 #endif
-
-	platform_set_drvdata(pdev, priv_data);
 
 	ret = devm_clk_bulk_get_all(priv_data->dev, &priv_data->clks);
 	if (ret < 0)


### PR DESCRIPTION
Call platform_set_drvdata before registering the regulator otherwise
it crashes if dwc3_xlnx_reg_is_enabled gets called right after the
registration (depending on the config used).

Crash dump:
[    2.414412] Unable to handle kernel NULL pointer dereference at virtual address 0000000000000038
[    2.423203] Mem abort info:
[    2.425982]   ESR = 0x96000005
[    2.429031]   EC = 0x25: DABT (current EL), IL = 32 bits
[    2.434338]   SET = 0, FnV = 0
[    2.437386]   EA = 0, S1PTW = 0
[    2.440517] Data abort info:
[    2.443392]   ISV = 0, ISS = 0x00000005
[    2.447218]   CM = 0, WnR = 0
[    2.450174] [0000000000000038] user address but active_mm is swapper
[    2.456518] Internal error: Oops: 96000005 [#1] SMP
[    2.461381] Modules linked in:
[    2.464431] CPU: 0 PID: 32 Comm: kworker/0:1 Not tainted 5.10.0-lmp-standard+ #2
[    2.471813] Hardware name: Avnet XCZU3EG-SFVA625 SoM (DT)
[    2.477206] Workqueue: events deferred_probe_work_func
[    2.482336] pstate: 60000005 (nZCv daif -PAN -UAO -TCO BTYPE=--)
[    2.488337] pc : dwc3_xlnx_reg_is_enabled+0x18/0x28
[    2.493206] lr : _regulator_is_enabled.part.0+0x28/0x40
[    2.498417] sp : ffffffc01190b8a0
[    2.501716] x29: ffffffc01190b8a0 x28: ffffff8000804e00
[    2.507019] x27: 0000000000000000 x26: ffffff8000950e00
[    2.512323] x25: ffffff8000951380 x24: ffffff8000852c10
[    2.517626] x23: ffffff80003c4880 x22: ffffffc01190b8f8
[    2.522930] x21: ffffff80019bc800 x20: ffffffc01190b905
[    2.528233] x19: 0000000000000092 x18: 0000000000000000
[    2.533537] x17: 0000000000000001 x16: 0000000000000019
[    2.538840] x15: ffffff80003c4d98 x14: 0000000000000000
[    2.544144] x13: 0000000000000000 x12: 0000000000000000
[    2.549447] x11: 0000000000000000 x10: 0000000000000000
[    2.554751] x9 : ffffffc01066b1e0 x8 : 0000000000000000
[    2.560054] x7 : ffffffc01190b8b0 x6 : ffffffc01190b905
[    2.565358] x5 : 0000000000000000 x4 : ffffff80003c4880
[    2.570661] x3 : 000000000000000d x2 : 0000000000000000
[    2.575965] x1 : ffffffc0108a31b0 x0 : 0000000000000000
[    2.581270] Call trace:
[    2.583704]  dwc3_xlnx_reg_is_enabled+0x18/0x28
[    2.588225]  print_constraints_debug+0x35c/0x428
[    2.592835]  set_machine_constraints+0x1f0/0x8d8
[    2.597443]  regulator_register+0x2f4/0xa38
[    2.601617]  devm_regulator_register+0x54/0xa0
[    2.606053]  dwc3_xlnx_register_regulator+0x64/0xc0
[    2.610922]  dwc3_xlnx_probe+0x8c/0x200
[    2.614751]  platform_drv_probe+0x5c/0xb0
[    2.618751]  really_probe+0xec/0x498
[    2.622319]  driver_probe_device+0x74/0x160
[    2.626494]  __device_attach_driver+0xa4/0x120
[    2.630931]  bus_for_each_drv+0x80/0xd8
[    2.634757]  __device_attach+0xfc/0x180
[    2.638577]  device_initial_probe+0x1c/0x28
[    2.642751]  bus_probe_device+0xa4/0xb0
[    2.646571]  deferred_probe_work_func+0x94/0xe8
[    2.651087]  process_one_work+0x1e8/0x468
[    2.655086]  worker_thread+0x278/0x4a8

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
