### PR TITLE
Fix the zynqmp qspi driver call to get the spi controller devdata

### DIFF
--- a/drivers/spi/spi-zynqmp-gqspi.c
+++ b/drivers/spi/spi-zynqmp-gqspi.c
@@ -1057,7 +1057,8 @@ static int __maybe_unused zynqmp_runtime_suspend(struct device *dev)
  */
 static int __maybe_unused zynqmp_runtime_resume(struct device *dev)
 {
-	struct zynqmp_qspi *xqspi = (struct zynqmp_qspi *)dev_get_drvdata(dev);
+	struct spi_controller *ctlr = dev_get_drvdata(dev);
+	struct zynqmp_qspi *xqspi = spi_controller_get_devdata(ctlr);
 	int ret;
 
 	ret = clk_enable(xqspi->pclk);
@@ -1239,7 +1240,8 @@ return_err:
 
 static int __maybe_unused zynqmp_runtime_idle(struct device *dev)
 {
-	struct zynqmp_qspi *xqspi = dev_get_drvdata(dev);
+	struct spi_controller *ctlr = dev_get_drvdata(dev);
+	struct zynqmp_qspi *xqspi = spi_controller_get_devdata(ctlr);
 	u32 value;
 
 	value = zynqmp_gqspi_read(xqspi, GQSPI_EN_OFST);


### PR DESCRIPTION
To get the spi controller device data, two dereferences are needed. The
zynqmp_runtime_resume() and zynqmp_runtime_idle() calls do not do the
proper pointer dereferencing resulting in the resume using an imvalid
pointer and thus trying to start a clock with an invalid pointer.

The error originated with this commit:
  1c26372e5aa9 (spi: spi-zynqmp-gqspi: Update driver to use spi-mem framework)

The error was fixed in zynqmp_runtime_suspend() and zynqmp_qspi_probe()
with this commit:
  a9a3879f324a (spi: spi-zynqmp-gqspi: Fix suspend resume failure)

This changeset fixes it also in zynqmp_runtime_resume() and
zynqmp_runtime_idle().

Signed-off-by: Gerald Van Baren <gvb@unssw.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please see
https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842172/Create+and+Submit+a+Patch
