### PR TITLE
Update xv_vscaler_setup_video_fmt function to avoid NV12 Vscale mismatch

### DIFF
--- a/drivers/gpu/drm/xlnx/xlnx_scaler.c
+++ b/drivers/gpu/drm/xlnx/xlnx_scaler.c
@@ -1479,6 +1479,12 @@ xv_vscaler_setup_video_fmt(struct xilinx_scaler *scaler, u32 code_in)
 	xilinx_scaler_write(scaler->base, V_VSCALER_OFF +
 			    XV_VSCALER_CTRL_ADDR_HWREG_COLORMODE_DATA,
 			    video_in);
+	/*
+	 * Vscaler will upscale to YUV 422 before
+	 * Hscaler starts operation
+	 */
+	if (video_in == XVIDC_CSF_YCRCB_420)
+		return XVIDC_CSF_YCRCB_422;
 	return video_in;
 }
 


### PR DESCRIPTION
To address the NV12 green screen overlay issue, we referred to the V4L2 VPSS driver. Based on these insights, we implemented changes in the DRM-VPSS driver, which now supports smooth NV12 color format rendering.