### PR TITLE
SPI NOR stacked config 64MB broken

### DIFF
--- a/drivers/mtd/spi-nor/core.c
+++ b/drivers/mtd/spi-nor/core.c
@@ -652,7 +652,7 @@ static int spi_nor_write_ear(struct spi_nor *nor, u32 addr)
 		return 0;
 	else if (((nor->flags & SNOR_F_HAS_PARALLEL) ||
 		  (nor->flags & SNOR_F_HAS_STACKED)) &&
-		 mtd->size <= OFFSET_16_MB * SNOR_FLASH_CNT_MAX)
+		 mtd->size < OFFSET_16_MB * SNOR_FLASH_CNT_MAX)
 		return 0;
 
 	if (!(nor->flags & SNOR_F_HAS_PARALLEL) || !(nor->flags & SNOR_F_HAS_STACKED))


### PR DESCRIPTION
Hi,

I noticed that when using a stacked QSPI configuration on a zynq7000 the EAR register never gets written. This happens because the addition of a new check. Validation if the EAR writing is actually needed. However the check thinks 64MB (so 2 x 32MB) does not need writing the EAR. However it most certainly needs it.

Thanks,

Wesley